### PR TITLE
SalaryAddViewで初期値を削除すると給与を追加できなくなる

### DIFF
--- a/JobShift.xcodeproj/project.pbxproj
+++ b/JobShift.xcodeproj/project.pbxproj
@@ -588,7 +588,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = JobShift/JobShift.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"JobShift/Preview Content\"";
 				DEVELOPMENT_TEAM = 8KH9QD5V23;
 				ENABLE_PREVIEWS = YES;
@@ -604,7 +604,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.shin.JobShift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -621,7 +621,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = JobShift/JobShift.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"JobShift/Preview Content\"";
 				DEVELOPMENT_TEAM = 8KH9QD5V23;
 				ENABLE_PREVIEWS = YES;
@@ -637,7 +637,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.shin.JobShift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/JobShift/View/Salary/SalaryAddView.swift
+++ b/JobShift/View/Salary/SalaryAddView.swift
@@ -9,6 +9,7 @@ struct SalaryAddView: View {
     @State var selectedJob: Job
     @Query private var jobs: [Job]
     @State private var salary: Int? = 0
+    @State private var salaryString: String = "0"
     @State private var showAlert = false
     @State private var pickerIsPresented = false
     
@@ -46,7 +47,7 @@ struct SalaryAddView: View {
                     }
                     HStack {
                         Text("給与")
-                        TextField("", value: $salary, formatter: NumberFormatter())
+                        TextField("", text: $salaryString)
                             .multilineTextAlignment(TextAlignment.trailing)
                             .keyboardType(.numberPad)
                         Text("円")
@@ -64,6 +65,7 @@ struct SalaryAddView: View {
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("追加") {
+                        self.salary = Int(salaryString) ?? nil
                         let existSalary = selectedJob.salaryHistories.first { $0.month == month && $0.year == year }
                         if existSalary != nil {
                             self.showAlert = true


### PR DESCRIPTION
## PR内容
SalaryAddViewで初期値である`0`を削除後、新規に数値を追加してもnilとして扱われ給料が追加されない不具合を修正